### PR TITLE
Add ProductsTypes API Documentation

### DIFF
--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import authentication from '@/routers/authentication';
 import people from '@/routers/people';
 import peopleCategories from '@/routers/peopleCategories';
+import products from '@/routers/products';
 import transactions from '@/routers/transactions/';
 import productExports from '@/routers/productExports';
 
@@ -11,6 +12,7 @@ const router = Router();
 router.use('/actions/authentication', authentication);
 router.use('/people', people);
 router.use('/peopleCategories', peopleCategories);
+router.use('/products', products);
 router.use('/transactions', transactions);
 router.use('/productExports', productExports);
 

--- a/src/routers/products.ts
+++ b/src/routers/products.ts
@@ -1,0 +1,34 @@
+import * as express from 'express';
+
+import createRouter from '@/utilities/functions/createRouter';
+import authorized from '@/middleware/authorized';
+import { UserType } from '@/models/User/UserType';
+
+import { StatusCode } from '@/models/statusCodes';
+
+const router = createRouter();
+
+/**
+ * @api {get} /peopleCategories Get All Product Types
+ * @apiName GetProductTypes
+ * @apiGroup ProductTypes
+ * @apiVersion  0.0.1
+ * @apiDescription Returns all types of products and their associated attributes
+ *
+ * @apiSuccess (200) {String} Success Successfully retrieved all product types
+ * @apiSuccessExample Success-Response:
+  {
+    milk: [
+      "density",
+      "viscosity"
+    ],
+    corn: [
+      "colour",
+    ]
+  }
+ */
+router.get('/', async (req, res) => {
+  res.status(StatusCode.OK).send('Successfully retrieved all product types');
+}, authorized(UserType.ADMIN));
+
+export default router;

--- a/src/routers/products.ts
+++ b/src/routers/products.ts
@@ -9,7 +9,7 @@ import { StatusCode } from '@/models/statusCodes';
 const router = createRouter();
 
 /**
- * @api {get} /peopleCategories Get All Product Types
+ * @api {get} /products Get All Product Types
  * @apiName GetProductTypes
  * @apiGroup ProductTypes
  * @apiVersion  0.0.1


### PR DESCRIPTION
Product API document is created in apidoc format.
API gives associated attributes for all product types.
Function stub is created at route /products.
Route added to route index file.